### PR TITLE
Make "Types of Financial Aid" button break in a more visually appealing manner

### DIFF
--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -60,7 +60,7 @@
   //   padding-top: $base-padding-lite;
   // }
 
-  @include respond-to(medium-up) {
+  @include respond-to(large-up) {
     @include span-columns(3);
     @include omega();
     margin-top: $base-padding;

--- a/school/index.html
+++ b/school/index.html
@@ -711,7 +711,7 @@ stylesheets:
       <div class="u-align_c">
 
         <a href="https://studentaid.ed.gov/sa/types#aid-from-the-federal-government" class="button button-outline" target="_blank">
-          Types of Financial Aid</a>
+          Types&nbsp;of Financial&nbsp;Aid</a>
         <a href="https://fafsa.ed.gov/FAFSA/app/f4cForm" class="button button-outline" target="_blank">
           Calculate Your Aid</a>
         <a href="https://www.vets.gov/gi-bill-comparison-tool" class="button button-outline" target="_blank">


### PR DESCRIPTION
Follow-up to #1431

Replaced the spaces in make the "Types of Financial Aid" button break on two lines better. 

Previous behavior:
![image](https://cloud.githubusercontent.com/assets/2475615/12905348/57726a6c-ce8b-11e5-8485-590d6f587423.png)

New behavior:
![screen shot 2016-02-08 at 5 38 09 pm](https://cloud.githubusercontent.com/assets/2475615/12905353/60aa4906-ce8b-11e5-88cb-3d4159625632.png)

Changed the CSS screen size breakpoint to prevent this happening on medium screens (on medium screens, the buttons now go beneath the main details just like they do on mobile currently):
![screen shot 2016-02-08 at 5 38 48 pm](https://cloud.githubusercontent.com/assets/2475615/12905363/7acc4168-ce8b-11e5-8661-2cd6dcda25d5.png)
