### PR TITLE
fix hidden width causing horizontal overflow

### DIFF
--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -215,6 +215,7 @@
     // don't show meter labels for top-level stats
     picc-meter .label {
       visibility: hidden;
+      left: 0;
     }
 
     @include respond-to(tiny-up) {


### PR DESCRIPTION
This fixes #1525

When on a mobile device or smaller screens, the top `school-meters` have a national average meter line with a hidden `<span class="label">` with absolute positioning that is exceeding the screen width and causing the overflow. 

Because the span is hidden for these top meter's (and the left positioning is not needed), this PR simply overrides the `picc-meter`'s [left positioning](https://github.com/18F/college-choice/blob/dev/_sass/base/components/_picc-meter.scss#L32) so that it won't overflow here. Other picc-meter instances retain the left positioning (those inside the dropdowns).