### PR TITLE
Fix for filter toggles rendering incorrectly in Firefox

### DIFF
--- a/_sass/base/components/_search-toggles.scss
+++ b/_sass/base/components/_search-toggles.scss
@@ -97,8 +97,8 @@ $toggle-padding: 15px;
   }
 
   @include respond-to(small-up) {
-    width: 214px;
     padding: $base-padding-lite $toggle-padding $base-padding-lite $toggle-padding;
+    width: 214px;
   }
 }
 

--- a/_sass/base/components/_search-toggles.scss
+++ b/_sass/base/components/_search-toggles.scss
@@ -93,11 +93,11 @@ $toggle-padding: 15px;
   padding: $base-padding-lite ($toggle-padding / 2) $base-padding-lite ($toggle-padding / 2);
 
   @include respond-to(teensy-up) {
-    width: 150px;
+    width: 154px;
   }
 
   @include respond-to(small-up) {
-    width: 210px;
+    width: 214px;
     padding: $base-padding-lite $toggle-padding $base-padding-lite $toggle-padding;
   }
 }


### PR DESCRIPTION
This PR is a small UI update to resolve an issue with the display of the chevron next to the filter on the search results page incorrectly wrapping on Firefox. 