### PR TITLE
Fix for checkbox borders not appearing in some browsers

### DIFF
--- a/_sass/base/components/_forms.scss
+++ b/_sass/base/components/_forms.scss
@@ -94,7 +94,7 @@ label.radio {
 
   input[type="checkbox"] + span {
     box-shadow: 0 0 1px $black;
-    border-radius: 1px;
+    /*border-radius: 1px;*/
     display: inline-block;
     height: 20px;
     margin-top: 0;


### PR DESCRIPTION
This PR fixes some missing checkboxes that don't appear in some browsers  (even though they are; no border to distinguish the space).