### PR TITLE
Fix mile radius search when number contains decimal or negative value

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ best suited to them, and ensure a broad and flexible definition of elements that
 
 This repo contains the front end of a web app with its API created by an instance of [Open Data Maker](https://github.com/18F/open-data-maker) which is configured with a specific data set. For more details on setting up the back end of the web app, see below: [Running the API Locally](#running-the-api-locally).  However, you can run the web app with the hosted API following the installation instructions in the next section.
 
+
 #### Build Status
 * [production](https://github.com/RTICWDT/college-scorecard/tree/master/) [![Circle CI](https://circleci.com/gh/RTICWDT/college-scorecard.svg?style=svg)](https://circleci.com/gh/RTICWDT/college-scorecard)
 * [staging](https://github.com/RTICWDT/college-scorecard/tree/staging/) [![Circle CI](https://circleci.com/gh/RTICWDT/college-scorecard/tree/staging.svg?style=svg)](https://circleci.com/gh/RTICWDT/college-scorecard/tree/staging)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then visit [http://localhost:4000](http://localhost:4000) to view it. The `-w`
 the source files.
 
 
+
 ## Front End Development
 
 ### Stylesheets

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -111,7 +111,7 @@
           </label>
 
           <label for="search-radius" class="group_inline-right">Mile radius
-            <input name="distance" type="number" step=".1" placeholder="10" value="10" id="search-radius" {{ common_input_attributes }}>
+            <input name="distance" type="number" step="1" min="1" pattern="^\d+$" placeholder="10" value="10" id="search-radius" {{ common_input_attributes }}>
           </label>
 
         </div>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -132,6 +132,7 @@
   </fieldset>
 
   <fieldset>
+
     <legend>Size</legend>
 
     <aria-accordion id="school-size" class="container">


### PR DESCRIPTION
This PR is a small fix to disallow location-based searches that include a number with a decimal point in the `Mile Radius` search input. This also disables a negative value being searched which returns an error from Open Data Maker. This addresses #1083, and #1332.
