### PR TITLE
Data Documentation Update

### DIFF
--- a/data/documentation.html
+++ b/data/documentation.html
@@ -327,7 +327,7 @@ permalink: /data/documentation/
 
       <h2>API Documentation</h2>
 
-      <p>The College Scorecard API is a GET API that lives at <span>http://api.data.gov/ed/collegescorecard</span></p>
+      <p>The College Scorecard API is a GET API that lives at <span>http://api.data.gov/ed/collegescorecard/</span></p>
       <p>The endpoint for querying all data is <span>/v1/schools</span></p>
 
       <h3>Structure</h3>


### PR DESCRIPTION
This is a small update to include a trailing slash on an API url on the data documentation page. It can be merged into the next set of site updates. 