### PR TITLE
Add outlying territories to state location select menu

### DIFF
--- a/_data/states.csv
+++ b/_data/states.csv
@@ -9,6 +9,7 @@ CO,Colorado
 CT,Connecticut
 DE,Delaware
 DC,District of Columbia
+FM,Federated States of Micronesia
 FL,Florida
 GA,Georgia
 GU,Guam
@@ -36,9 +37,12 @@ NM,New Mexico
 NY,New York
 NC,North Carolina
 ND,North Dakota
+MH, Marshall Islands
+MP,Northern Mariana Islands
 OH,Ohio
 OK,Oklahoma
 OR,Oregon
+PW,Palau
 PA,Pennsylvania
 PR,Puerto Rico
 RI,Rhode Island


### PR DESCRIPTION
This is in addition to the "region" location select menu (Outlying Areas).