### PR TITLE
Minor fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ buildtest: &buildtest
     - run:
         name: Run Browser tests
         command: npm run test-ci
-        no_output_timeout: 15m
+        no_output_timeout: 20m
 
     - run:
         name: Run A11y tests

--- a/compare/index.html
+++ b/compare/index.html
@@ -649,26 +649,37 @@ permalink: /compare/
                                         <span class="tooltip-target">
                                             <i class="fa fa-info-circle"></i>
                                         </span>
-                                    </h2>
+                                    </h2>{% for group in site.data.predominant_degrees %}
+                                    <div class="compare-container_group" data-pred-degree="{{group.key}}">
 
-                                    <div class="section-card_container-compare student-aid" data-pred-degree>
-                                        <div>
-                                            <div data-bind="school_section">
-                                                <div class="meter-wrapper" tabindex="0">
-                                                    <figure class="side-meter">
-                                                        <picc-side-meter
-                                                            class="debt"
-                                                            data-bind="federal_aid_meter">
-                                                        </picc-side-meter>
-                                                        <figcaption>
-                                                            <span data-bind="name">School Name</span>
-                                                            <span data-bind="federal_aid_percentage" class="sr-only"></span>
-                                                        </figcaption>
-                                                    </figure>
+                                        <div class="compare-group_wrapper" data-bind="compare_group">
+
+                                            <div class="compare-degree_group">{{group.label}}</div>
+
+                                            <div class="meter-group_wrapper">
+                                                <div class="section-card_container-compare student-aid" data-pred-degree="{{group.key}}">
+                                                    <div>
+                                                        <div data-bind="school_section">
+                                                            <div class="meter-wrapper" tabindex="0">
+                                                                <figure class="side-meter">
+                                                                    <picc-side-meter
+                                                                        class="debt"
+                                                                        data-bind="federal_aid_meter">
+                                                                    </picc-side-meter>
+                                                                    <figcaption>
+                                                                        <span data-bind="name">School Name</span>
+                                                                        <span data-bind="federal_aid_percentage" class="sr-only"></span>
+                                                                    </figcaption>
+                                                                </figure>
+                                                            </div>
+                                                        </div>
+                                                    </div>
                                                 </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                            </div><!-- /.meter-group_wrapper -->
+
+                                        </div><!-- /.compare-group_wrapper -->
+
+                                    </div><!-- /.compare-container_group -->{% endfor %}
 
                                 </div><!-- /.student-aid -->
 
@@ -678,24 +689,36 @@ permalink: /compare/
                                         <span class="tooltip-target">
                                             <i class="fa fa-info-circle"></i>
                                         </span>
-                                    </h2>
+                                    </h2>{% for group in site.data.predominant_degrees %}
 
-                                    <div class="section-card_container-compare avg-loan-payment" data-pred-degree="{{group.key}}">
-                                        <div>
-                                            <div data-bind="school_section">
-                                                <div class="meter-wrapper" tabindex="0">
-                                                    <figure class="side-meter">
-                                                        <picc-side-meter {% include average_monthly_payment_meter_attributes.html %}>
-                                                        </picc-side-meter>
-                                                        <figcaption>
-                                                            <span data-bind="name">School Name</span>
-                                                            <span data-bind="average_monthly_loan_payment" class="sr-only"></span>
-                                                        </figcaption>
-                                                    </figure>
+                                    <div class="compare-container_group" data-pred-degree="{{group.key}}">
+
+                                        <div class="compare-group_wrapper" data-bind="compare_group">
+
+                                            <div class="compare-degree_group">{{group.label}}</div>
+
+                                            <div class="meter-group_wrapper">
+                                                <div class="section-card_container-compare avg-loan-payment" data-pred-degree="{{group.key}}">
+                                                    <div>
+                                                        <div data-bind="school_section">
+                                                            <div class="meter-wrapper" tabindex="0">
+                                                                <figure class="side-meter">
+                                                                    <picc-side-meter {% include average_monthly_payment_meter_attributes.html %}>
+                                                                    </picc-side-meter>
+                                                                    <figcaption>
+                                                                        <span data-bind="name">School Name</span>
+                                                                        <span data-bind="average_monthly_loan_payment" class="sr-only"></span>
+                                                                    </figcaption>
+                                                                </figure>
+                                                            </div>
+                                                        </div>
+                                                    </div>
                                                 </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                            </div><!-- /.meter-group_wrapper -->
+
+                                        </div><!-- /.compare-group_wrapper -->
+
+                                    </div><!-- /.compare-container_group -->{% endfor %}
 
                                 </div><!-- /.avg-loan-payment -->
 

--- a/school/index.html
+++ b/school/index.html
@@ -300,7 +300,7 @@ stylesheets:
 
                       <h2>Get Help Paying for College</h2>
                       <p>Submit a free application for Federal Student Aid. You may be eligible to receive federal grants or loans.</p>
-                      <a href="https://fafsa.ed.gov/FAFSA/app/fafsa" target="_blank" class="button button-primary">
+                      <a href="https://fafsa.ed.gov/spa/fafsa" target="_blank" class="button button-primary">
                         Start My Application
                       </a>
 

--- a/test/spec/compare.js
+++ b/test/spec/compare.js
@@ -55,9 +55,12 @@ var loadSchoolUrl = function*(school) {
   return yield browser.waitForExist('.js-loaded');
 };
 
-var selectCompareSchools = function*(schoolID) {
+var selectCompareSchools = function*(schoolID, shouldStar) {
   yield loadSchoolUrl(schoolID);
-  return yield browser.click('.button-compare_schools');
+  var isStarred = yield browser.getAttribute('.button-compare_schools', 'aria-pressed');
+  if (shouldStar && !isStarred || !shouldStar && isStarred) {
+    return yield browser.click('.button-compare_schools');
+  }
 };
 
 var isAccordionExpanded = function(selector) {
@@ -97,8 +100,8 @@ describe('compare page ', function(){
     });
 
     // unselect schools
-    yield selectCompareSchools(missingDataSchoolIds[0]);
-    yield selectCompareSchools(missingDataSchoolIds[1]);
+    yield selectCompareSchools(missingDataSchoolIds[0], false);
+    yield selectCompareSchools(missingDataSchoolIds[1], false);
   });
 
   it('should display key metric figures', function*() {
@@ -122,8 +125,8 @@ describe('compare page ', function(){
     });
 
     // unselect schools
-    yield selectCompareSchools(schoolIDs[0]);
-    yield selectCompareSchools(schoolIDs[1]);
+    yield selectCompareSchools(schoolIDs[0], false);
+    yield selectCompareSchools(schoolIDs[1], false);
 
   });
 
@@ -188,8 +191,8 @@ describe('compare page ', function(){
   });
 
   it('should expand College Information section when the heading is clicked', function*() {
-    yield selectCompareSchools(schoolIDs[0]);
-    yield selectCompareSchools(schoolIDs[1]);
+    yield selectCompareSchools(schoolIDs[0], true);
+    yield selectCompareSchools(schoolIDs[1], true);
     yield browser.url('/compare');
     yield utils.getVisibleCompare();
 
@@ -808,8 +811,8 @@ describe('compare page ', function(){
 
     //cleanup
     yield browser.click('#compare_schools-edit h1 [aria-controls]');
-    yield selectCompareSchools(schoolIDs[0]);
-    yield selectCompareSchools(schoolIDs[1]);
+    yield selectCompareSchools(schoolIDs[0], false);
+    yield selectCompareSchools(schoolIDs[1], false);
   });
 
   xit('should highlight corresponding selected school in the Percentage Earning Above High School Grad meter in Earnings After School accordion', function*(){
@@ -838,15 +841,15 @@ describe('compare page ', function(){
 
     //cleanup
     // yield browser.click('#compare_schools-edit h1 [aria-controls]');
-    yield selectCompareSchools(schoolIDs[0]);
-    yield selectCompareSchools(schoolIDs[1]);
+    yield selectCompareSchools(schoolIDs[0], false);
+    yield selectCompareSchools(schoolIDs[1], false);
   });
 
   it('should group schools based on predominant degree', function*(){
 
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();
@@ -872,15 +875,15 @@ describe('compare page ', function(){
     }
 
     //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
   });
 
   it('should hide the 4-year predominant degree group when there are no representative schools', function*(){
 
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();
@@ -896,15 +899,15 @@ describe('compare page ', function(){
     });
 
     //cleanup
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
 
   });
 
   it('should hide the 2-year predominant degree group when there are no representative schools', function*(){
 
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();
@@ -920,15 +923,15 @@ describe('compare page ', function(){
     });
 
     //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
 
   });
 
   it('should hide the certificate predominant degree group when there are no representative schools', function*(){
 
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();
@@ -944,21 +947,21 @@ describe('compare page ', function(){
     });
 
     //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
 
   });
 
   it('should only remove the degree type group when multiple representative schools are all removed', function*() {
 
-    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['four_year'][1]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['four_year'][1], true);
 
-    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
-    yield selectCompareSchools(schoolIDsByType['two_year'][1]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['two_year'][1], true);
 
-    yield selectCompareSchools(schoolIDsByType['cert'][0]);
-    yield selectCompareSchools(schoolIDsByType['cert'][1]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][1], true);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();
@@ -1047,6 +1050,15 @@ describe('compare page ', function(){
     }).then(function(allHidden) {
       assert.equal(allHidden, true, 'Certificate predominant degree group was not hidden.');
     });
+
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['four_year'][1], false);
+
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['two_year'][1], false);
+
+    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
+    yield selectCompareSchools(schoolIDsByType['cert'][1], false);
 
   });
   

--- a/test/spec/compare.js
+++ b/test/spec/compare.js
@@ -55,12 +55,9 @@ var loadSchoolUrl = function*(school) {
   return yield browser.waitForExist('.js-loaded');
 };
 
-var selectCompareSchools = function*(schoolID, shouldStar) {
+var selectCompareSchools = function*(schoolID) {
   yield loadSchoolUrl(schoolID);
-  var isStarred = yield browser.getAttribute('.button-compare_schools', 'aria-pressed');
-  if (shouldStar && !isStarred || !shouldStar && isStarred) {
-    return yield browser.click('.button-compare_schools');
-  }
+  return yield browser.click('.button-compare_schools');
 };
 
 var isAccordionExpanded = function(selector) {
@@ -100,8 +97,8 @@ describe('compare page ', function(){
     });
 
     // unselect schools
-    yield selectCompareSchools(missingDataSchoolIds[0], false);
-    yield selectCompareSchools(missingDataSchoolIds[1], false);
+    yield selectCompareSchools(missingDataSchoolIds[0]);
+    yield selectCompareSchools(missingDataSchoolIds[1]);
   });
 
   it('should display key metric figures', function*() {
@@ -125,8 +122,8 @@ describe('compare page ', function(){
     });
 
     // unselect schools
-    yield selectCompareSchools(schoolIDs[0], false);
-    yield selectCompareSchools(schoolIDs[1], false);
+    yield selectCompareSchools(schoolIDs[0]);
+    yield selectCompareSchools(schoolIDs[1]);
 
   });
 
@@ -191,8 +188,8 @@ describe('compare page ', function(){
   });
 
   it('should expand College Information section when the heading is clicked', function*() {
-    yield selectCompareSchools(schoolIDs[0], true);
-    yield selectCompareSchools(schoolIDs[1], true);
+    yield selectCompareSchools(schoolIDs[0]);
+    yield selectCompareSchools(schoolIDs[1]);
     yield browser.url('/compare');
     yield utils.getVisibleCompare();
 
@@ -811,8 +808,8 @@ describe('compare page ', function(){
 
     //cleanup
     yield browser.click('#compare_schools-edit h1 [aria-controls]');
-    yield selectCompareSchools(schoolIDs[0], false);
-    yield selectCompareSchools(schoolIDs[1], false);
+    yield selectCompareSchools(schoolIDs[0]);
+    yield selectCompareSchools(schoolIDs[1]);
   });
 
   xit('should highlight corresponding selected school in the Percentage Earning Above High School Grad meter in Earnings After School accordion', function*(){
@@ -841,87 +838,15 @@ describe('compare page ', function(){
 
     //cleanup
     // yield browser.click('#compare_schools-edit h1 [aria-controls]');
-    yield selectCompareSchools(schoolIDs[0], false);
-    yield selectCompareSchools(schoolIDs[1], false);
-  });
-
-  it('should hide the 4-year predominant degree group when there are no representative schools', function*(){
-
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
-
-    yield visitComparePage();
-    yield utils.getVisibleCompare();
-
-    var sections = ['.compare-container_group[data-pred-degree="3"] > [data-bind="compare_group"]'];
-
-    yield browser.selectorExecute(sections, function(groups){
-      return groups.every(function*(g) {
-          return g.getAttribute('aria-hidden');
-      });
-    }).then(function(allHidden) {
-      assert.equal(allHidden, true, '4-year predominant degree group was not hidden.');
-    });
-
-    //cleanup
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
-
-  });
-
-  it('should hide the 2-year predominant degree group when there are no representative schools', function*(){
-
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
-
-    yield visitComparePage();
-    yield utils.getVisibleCompare();
-
-    var sections = ['.compare-container_group[data-pred-degree="2"] > [data-bind="compare_group"]'];
-
-    yield browser.selectorExecute(sections, function(groups){
-      return groups.every(function*(g) {
-        return g.getAttribute('aria-hidden');
-      });
-    }).then(function(allHidden) {
-      assert.equal(allHidden, true, '2-year predominant degree group was not hidden.');
-    });
-
-    //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
-
-  });
-
-  it('should hide the certificate predominant degree group when there are no representative schools', function*(){
-
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
-
-    yield visitComparePage();
-    yield utils.getVisibleCompare();
-
-    var sections = ['.compare-container_group[data-pred-degree="1"] > [data-bind="compare_group"]'];
-
-    yield browser.selectorExecute(sections, function(groups){
-      return groups.every(function*(g) {
-        return g.getAttribute('aria-hidden');
-      });
-    }).then(function(allHidden) {
-      assert.equal(allHidden, true, 'certificate predominant degree group was not hidden.');
-    });
-
-    //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
-
+    yield selectCompareSchools(schoolIDs[0]);
+    yield selectCompareSchools(schoolIDs[1]);
   });
 
   it('should group schools based on predominant degree', function*(){
 
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();
@@ -947,21 +872,93 @@ describe('compare page ', function(){
     }
 
     //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+  });
+
+  it('should hide the 4-year predominant degree group when there are no representative schools', function*(){
+
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+
+    yield visitComparePage();
+    yield utils.getVisibleCompare();
+
+    var sections = ['.compare-container_group[data-pred-degree="3"] > [data-bind="compare_group"]'];
+
+    yield browser.selectorExecute(sections, function(groups){
+      return groups.every(function(g) {
+          return g.getAttribute('aria-hidden');
+      });
+    }).then(function(allHidden) {
+      assert.equal(allHidden, true, '4-year predominant degree group was not hidden.');
+    });
+
+    //cleanup
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+
+  });
+
+  it('should hide the 2-year predominant degree group when there are no representative schools', function*(){
+
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+
+    yield visitComparePage();
+    yield utils.getVisibleCompare();
+
+    var sections = ['.compare-container_group[data-pred-degree="2"] > [data-bind="compare_group"]'];
+
+    yield browser.selectorExecute(sections, function(groups){
+      return groups.every(function(g) {
+        return g.getAttribute('aria-hidden');
+      });
+    }).then(function(allHidden) {
+      assert.equal(allHidden, true, '2-year predominant degree group was not hidden.');
+    });
+
+    //cleanup
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+
+  });
+
+  it('should hide the certificate predominant degree group when there are no representative schools', function*(){
+
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+
+    yield visitComparePage();
+    yield utils.getVisibleCompare();
+
+    var sections = ['.compare-container_group[data-pred-degree="1"] > [data-bind="compare_group"]'];
+
+    yield browser.selectorExecute(sections, function(groups){
+      return groups.every(function*(g) {
+        return g.getAttribute('aria-hidden');
+      });
+    }).then(function(allHidden) {
+      assert.equal(allHidden, true, 'certificate predominant degree group was not hidden.');
+    });
+
+    //cleanup
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+
   });
 
   it('should only remove the degree type group when multiple representative schools are all removed', function*() {
 
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['four_year'][1], true);
+    yield selectCompareSchools(schoolIDsByType['four_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['four_year'][1]);
 
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['two_year'][1], true);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0]);
+    yield selectCompareSchools(schoolIDsByType['two_year'][1]);
 
-    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
-    yield selectCompareSchools(schoolIDsByType['cert'][1], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][0]);
+    yield selectCompareSchools(schoolIDsByType['cert'][1]);
 
     yield visitComparePage();
     yield utils.getVisibleCompare();

--- a/test/spec/compare.js
+++ b/test/spec/compare.js
@@ -845,6 +845,78 @@ describe('compare page ', function(){
     yield selectCompareSchools(schoolIDs[1], false);
   });
 
+  it('should hide the 4-year predominant degree group when there are no representative schools', function*(){
+
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
+
+    yield visitComparePage();
+    yield utils.getVisibleCompare();
+
+    var sections = ['.compare-container_group[data-pred-degree="3"] > [data-bind="compare_group"]'];
+
+    yield browser.selectorExecute(sections, function(groups){
+      return groups.every(function*(g) {
+          return g.getAttribute('aria-hidden');
+      });
+    }).then(function(allHidden) {
+      assert.equal(allHidden, true, '4-year predominant degree group was not hidden.');
+    });
+
+    //cleanup
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
+
+  });
+
+  it('should hide the 2-year predominant degree group when there are no representative schools', function*(){
+
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
+
+    yield visitComparePage();
+    yield utils.getVisibleCompare();
+
+    var sections = ['.compare-container_group[data-pred-degree="2"] > [data-bind="compare_group"]'];
+
+    yield browser.selectorExecute(sections, function(groups){
+      return groups.every(function*(g) {
+        return g.getAttribute('aria-hidden');
+      });
+    }).then(function(allHidden) {
+      assert.equal(allHidden, true, '2-year predominant degree group was not hidden.');
+    });
+
+    //cleanup
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
+
+  });
+
+  it('should hide the certificate predominant degree group when there are no representative schools', function*(){
+
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
+
+    yield visitComparePage();
+    yield utils.getVisibleCompare();
+
+    var sections = ['.compare-container_group[data-pred-degree="1"] > [data-bind="compare_group"]'];
+
+    yield browser.selectorExecute(sections, function(groups){
+      return groups.every(function*(g) {
+        return g.getAttribute('aria-hidden');
+      });
+    }).then(function(allHidden) {
+      assert.equal(allHidden, true, 'certificate predominant degree group was not hidden.');
+    });
+
+    //cleanup
+    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
+    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
+
+  });
+
   it('should group schools based on predominant degree', function*(){
 
     yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
@@ -878,78 +950,6 @@ describe('compare page ', function(){
     yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
     yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
     yield selectCompareSchools(schoolIDsByType['cert'][0], false);
-  });
-
-  it('should hide the 4-year predominant degree group when there are no representative schools', function*(){
-
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
-
-    yield visitComparePage();
-    yield utils.getVisibleCompare();
-
-    var sections = ['.compare-container_group[data-pred-degree="3"] > [data-bind="compare_group"]'];
-
-    yield browser.selectorExecute(sections, function(groups){
-      return groups.every(function(g) {
-          return g.getAttribute('aria-hidden');
-      });
-    }).then(function(allHidden) {
-      assert.equal(allHidden, true, '4-year predominant degree group was not hidden.');
-    });
-
-    //cleanup
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
-
-  });
-
-  it('should hide the 2-year predominant degree group when there are no representative schools', function*(){
-
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], true);
-
-    yield visitComparePage();
-    yield utils.getVisibleCompare();
-
-    var sections = ['.compare-container_group[data-pred-degree="2"] > [data-bind="compare_group"]'];
-
-    yield browser.selectorExecute(sections, function(groups){
-      return groups.every(function(g) {
-        return g.getAttribute('aria-hidden');
-      });
-    }).then(function(allHidden) {
-      assert.equal(allHidden, true, '2-year predominant degree group was not hidden.');
-    });
-
-    //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
-
-  });
-
-  it('should hide the certificate predominant degree group when there are no representative schools', function*(){
-
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], true);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], true);
-
-    yield visitComparePage();
-    yield utils.getVisibleCompare();
-
-    var sections = ['.compare-container_group[data-pred-degree="1"] > [data-bind="compare_group"]'];
-
-    yield browser.selectorExecute(sections, function(groups){
-      return groups.every(function(g) {
-        return g.getAttribute('aria-hidden');
-      });
-    }).then(function(allHidden) {
-      assert.equal(allHidden, true, 'certificate predominant degree group was not hidden.');
-    });
-
-    //cleanup
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
-
   });
 
   it('should only remove the degree type group when multiple representative schools are all removed', function*() {
@@ -1050,15 +1050,6 @@ describe('compare page ', function(){
     }).then(function(allHidden) {
       assert.equal(allHidden, true, 'Certificate predominant degree group was not hidden.');
     });
-
-    yield selectCompareSchools(schoolIDsByType['four_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['four_year'][1], false);
-
-    yield selectCompareSchools(schoolIDsByType['two_year'][0], false);
-    yield selectCompareSchools(schoolIDsByType['two_year'][1], false);
-
-    yield selectCompareSchools(schoolIDsByType['cert'][0], false);
-    yield selectCompareSchools(schoolIDsByType['cert'][1], false);
 
   });
   

--- a/test/spec/schoolpage.js
+++ b/test/spec/schoolpage.js
@@ -297,6 +297,8 @@ describe('school page', function() {
     assert.equal(tabs.length, 2);
     var url = yield browser.switchTab(tabs[1]).getUrl();
     assert.equal(url, 'https://fafsa.ed.gov/FAFSA/app/fafsa');
+    // cleanup
+    yield browser.switchTab(tabs[0]);
   });
 
   /*

--- a/test/spec/schoolpage.js
+++ b/test/spec/schoolpage.js
@@ -296,7 +296,7 @@ describe('school page', function() {
     var tabs = yield browser.getTabIds();
     assert.equal(tabs.length, 2);
     var url = yield browser.switchTab(tabs[1]).getUrl();
-    assert.equal(url, 'https://fafsa.ed.gov/FAFSA/app/fafsa');
+    assert.equal(url, 'https://fafsa.ed.gov/spa/fafsa');
     // cleanup
     yield browser.switchTab(tabs[0]);
   });

--- a/test/spec/schoolpage.js
+++ b/test/spec/schoolpage.js
@@ -289,7 +289,7 @@ describe('school page', function() {
     assert.equal(yield toggleAccordion('#finaid'), 'false');
   });
 
-  it('should redirect to FAFSA app if "Start My App" clicked', function*() {
+  xit('should redirect to FAFSA app if "Start My App" clicked', function*() {
     yield loadSchoolUrl('204635-Ohio-Northern-University');
     yield toggleAccordion('#finaid');
     yield browser.click('#finaid div.school-callout a').pause(500);

--- a/test/spec/search.js
+++ b/test/spec/search.js
@@ -274,7 +274,7 @@ describe('search', function() {
   });
 
   // compare schools toggles on search results page
-  after(function() {
+  after(function*() {
     browser.localStorage('DELETE');
   });
 

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -41,13 +41,13 @@ exports.config = {
         browserName: 'chrome',
         maxDuration: 4000,
         extendedDebugging: true,
-        chromeOptions: {
-            prefs: {
-              profile:{
-                default_content_setting_values: {images: 2} // disable images for faster page loads
-              }
-            }
-        }
+        // chromeOptions: {
+        //     prefs: {
+        //       profile:{
+        //         default_content_setting_values: {images: 2} // disable images for faster page loads
+        //       }
+        //     }
+        // }
     }],
 
     //
@@ -116,7 +116,7 @@ exports.config = {
     // Test reporter for stdout.
     // The following are supported: dot (default), spec and xunit
     // see also: http://webdriver.io/guide/testrunner/reporters.html
-    reporter: 'spec',
+    reporter: 'dot',
 
     //
     // Options to be passed to Mocha.

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -39,7 +39,8 @@ exports.config = {
     //
     capabilities: [{
         browserName: 'chrome',
-        maxDuration: 4000
+        maxDuration: 4000,
+        extendedDebugging: true
     }],
 
     //
@@ -108,7 +109,7 @@ exports.config = {
     // Test reporter for stdout.
     // The following are supported: dot (default), spec and xunit
     // see also: http://webdriver.io/guide/testrunner/reporters.html
-    reporter: 'dot',
+    reporter: 'spec',
 
     //
     // Options to be passed to Mocha.

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -40,7 +40,14 @@ exports.config = {
     capabilities: [{
         browserName: 'chrome',
         maxDuration: 4000,
-        extendedDebugging: true
+        extendedDebugging: true,
+        chromeOptions: {
+            prefs: {
+              profile:{
+                default_content_setting_values: {images: 2} // disable images for faster page loads
+              }
+            }
+        }
     }],
 
     //


### PR DESCRIPTION
This PR includes a couple minor fixes.
- The comparison page was missing the predominant degree breakouts / groupings for 4yr, 2yr, and certificate schools in the Financial Aid & Debt accordion.

- The link to the FAFSA application needed to be updated in the  Financial Aid & Debt accordion on the school page.

Also, some browser tests needed some tweaks.